### PR TITLE
Eliminate ActiveSupport::Concern deprecation warning

### DIFF
--- a/lib/grouped_validations.rb
+++ b/lib/grouped_validations.rb
@@ -34,60 +34,57 @@ module GroupedValidations
 
   end
 
-  module InstanceMethods
-
-    def valid?(context=nil)
-      super
-      validation_groups.each do |group|
-        _run_group_validation_callbacks(group, context)
-      end
-      errors.empty?
+  def valid?(context=nil)
+    super
+    validation_groups.each do |group|
+      _run_group_validation_callbacks(group, context)
     end
-
-    def groups_valid?(*groups)
-      options = groups.extract_options!
-      errors.clear
-      groups.each do |group|
-        raise "Validation group '#{group}' not defined" unless validation_groups.include?(group)
-        _run_group_validation_callbacks(group, options[:context])
-      end
-      errors.empty?
-    end
-    alias_method :group_valid?, :groups_valid?
-
-    def grouped_errors(context=nil)
-      original_errors = @errors.dup if @errors
-      @errors = nil
-      grouped = {}
-
-      with_validation_context(context) do
-        _run_validate_callbacks
-        grouped[nil] = @errors
-
-        validation_groups.each do |group|
-          @errors = nil
-          send(:"_run_validate_#{group}_callbacks")
-          grouped[group] = @errors
-        end
-      end
-      grouped.values.all?(&:empty?) ? {} : grouped
-    ensure
-      @errors = original_errors
-    end
-
-    def _run_group_validation_callbacks(group, context=nil)
-      with_validation_context(context) do
-        send(:"_run_validate_#{group}_callbacks")
-      end
-    end
-
-    def with_validation_context(context)
-      context ||= (persisted? ? :update : :create)
-      current_context, self.validation_context = validation_context, context
-      yield
-    ensure
-      self.validation_context = current_context
-    end
-
+    errors.empty?
   end
+
+  def groups_valid?(*groups)
+    options = groups.extract_options!
+    errors.clear
+    groups.each do |group|
+      raise "Validation group '#{group}' not defined" unless validation_groups.include?(group)
+      _run_group_validation_callbacks(group, options[:context])
+    end
+    errors.empty?
+  end
+  alias_method :group_valid?, :groups_valid?
+
+  def grouped_errors(context=nil)
+    original_errors = @errors.dup if @errors
+    @errors = nil
+    grouped = {}
+
+    with_validation_context(context) do
+      _run_validate_callbacks
+      grouped[nil] = @errors
+
+      validation_groups.each do |group|
+        @errors = nil
+        send(:"_run_validate_#{group}_callbacks")
+        grouped[group] = (@errors.respond_to?(:messages) ? @errors.messages : @errors)
+      end
+    end
+    grouped.values.all?(&:empty?) ? {} : grouped
+  ensure
+    @errors = original_errors
+  end
+
+  def _run_group_validation_callbacks(group, context=nil)
+    with_validation_context(context) do
+      send(:"_run_validate_#{group}_callbacks")
+    end
+  end
+
+  def with_validation_context(context)
+    context ||= (persisted? ? :update : :create)
+    current_context, self.validation_context = validation_context, context
+    yield
+  ensure
+    self.validation_context = current_context
+  end
+
 end


### PR DESCRIPTION
Eliminated ActiveSupport::Concern deprecation warnings related to InstanceMethods module.

Also added check on validation errors to be compatible with Rails 3.2.

Specs pass with Rails 3.0 and 3.2.

See this with the only logic change in the file:
https://github.com/Capncavedan/grouped_validations/commit/5801121bdd5329a41ef986b8307ad6780ade2f67#commitcomment-1228479
