### PR TITLE
Fix for Issue 6 - undefined method empty? for nil class

### DIFF
--- a/lib/grouped_validations.rb
+++ b/lib/grouped_validations.rb
@@ -60,12 +60,12 @@ module GroupedValidations
 
     with_validation_context(context) do
       _run_validate_callbacks
-      grouped[nil] = @errors
+      grouped[nil] = errors
 
       validation_groups.each do |group|
         @errors = nil
         send(:"_run_validate_#{group}_callbacks")
-        grouped[group] = @errors
+        grouped[group] = errors
       end
     end
     grouped.values.all?(&:empty?) ? {} : grouped


### PR DESCRIPTION
Ive fixed #6 so that it now uses the object.errors getter method which will prevent nil being a value in the grouped errors hash
